### PR TITLE
Remove "Abort: trap6" error

### DIFF
--- a/BluesnapSDK/BluesnapSDK/BSApplepayPayment.swift
+++ b/BluesnapSDK/BluesnapSDK/BSApplepayPayment.swift
@@ -43,11 +43,11 @@ extension PKPaymentMethodType: CustomStringConvertible {
 
 public class BSApplePayInfo
 {
-    public var tokenPaymentNetwork: String!
-    public var tokenPaymentNetworkType: String!
-    public var token: PKPaymentToken!
-    public var tokenInstrumentName:String!
-    public var transactionId: String!
+    public var tokenPaymentNetwork: String?
+    public var tokenPaymentNetworkType: String
+    public var token: PKPaymentToken
+    public var tokenInstrumentName:String?
+    public var transactionId: String
     public let payment: PKPayment
     public var billingContact: PKContact?
     public var shippingContact: PKContact?


### PR DESCRIPTION
This PR removes the "Abort: trap 6" compile error in Xcode 10.2 by removing the use of implicitly unwrapped optionals in BSApplepayPayment